### PR TITLE
升级版本

### DIFF
--- a/cantor.typ
+++ b/cantor.typ
@@ -1,6 +1,4 @@
-#import "@preview/tablex:0.0.6": tablex, hlinex, vlinex
-
-#import "template.typ": project, remark, pseudonyms, example
+#import "template.typ": project, remark, pseudonyms, example, table-header
 
 #show: project.with(title: "既连续又本质间断", date: "2023年10月23–24日，11月7、13–14、16–20日，12月16日，2024年1月3日")
 
@@ -299,19 +297,15 @@ $X$ 内有一点 $x$，考查 $x$ 的邻域 $U$ 和去心邻域 $U^0 := U withou
 例如，若一个集合等于其导集，则称它*perfect*，这等价于它是无孤立点的闭集。更多定义如@tab:def-pairs。
 
 #figure(
-  tablex(
-    columns: (auto, auto),
-    auto-vlines: false,
-    auto-hlines: false,
-    [*原集合的性质*], vlinex(), [*补集相应性质*],
-    hlinex(),
+  table(
+    columns: 2,
+    table-header[原集合的性质][补集相应性质],
     [开 open #h(1fr)——边界全无], [闭 closed #h(1fr)——边界全管],
     [稠密 dense #h(1fr)——闭包取满#footnote[稠密必须谈背景，这里默认在 $RR$ 中。]], [无内点 has empty interior],
     [内点稠密 has dense interior], [无处稠密 nowhere dense #h(1fr)——闭包也无内点],
     [$G_delta$ #h(1fr)——开集的可数交], [$F_sigma$ #h(1fr)——闭集的可数并],
     [comeagre#footnote[我尝试了多种翻译服务，大多原样返回，仅DeepL和必应有时会翻译：前者给出`""`（一对引号）或“蔚为大观”，后者给出“科马格雷”。]], [疏朗 meagre#footnote[又叫first category，意思是按meagre与否将集合分为两类。不过取“第一”“第二”这种名字，还不如随机地叫“元伶外夜承”“承夜外伶元”，那样既强调仅有两类，又不会与其它术语混淆。另外，这个category常译作“纲”（→界门纲目科属种），但容易误以为提纲、纲领，所以我们也不采用。] #h(1fr)——无处稠密集的可数并],
   ),
-  kind: table,
   caption: [Baire空间涉及的若干性质]
 ) <tab:def-pairs>
 
@@ -322,20 +316,18 @@ $X$ 内有一点 $x$，考查 $x$ 的邻域 $U$ 和去心邻域 $U^0 := U withou
 #example[$QQ$ 的性质][在 $RR$ 中，$QQ$ 有如下性质。
   #show "❌": text.with(fill: red)
   #show "✅": text.with(fill: green)
+  #show regex("[❌✅]"): set text(font: "Segoe UI Emoji")
+
   #figure(
-    tablex(
-      columns: (auto, auto),
-      auto-vlines: false,
-      auto-hlines: false,
-      [*一种性质*], vlinex(), [*另一种性质*],
-      hlinex(),
+    table(
+      columns: 2,
+      table-header[一种性质][另一种性质],
       [❌开], [❌闭],
       [✅稠密], [✅无内点],
       [❌内点稠密], [❌无处稠密],
       [❌$G_delta$], [✅$F_sigma$],
       [❌comeagre], [✅meagre],
     ),
-    kind: table,
     caption: [$QQ$ 在 $RR$ 中的性质]
   )
 

--- a/fourier.typ
+++ b/fourier.typ
@@ -260,7 +260,7 @@ $
 其中 $p$ 取遍质数。
 
 #remark[证明Euler积公式][
-  这个证明重写了一遍Ἐρατοσθένης #footnote[Ἐρατοσθένης (Eratosthenes) 这个名字的词源是 _ἐρᾰτός_ (eratós, “lovely”) + _σθένος_ (sthénos, “strong”)。] 质数筛，改写自Euler原文。
+  这个证明重写了一遍Ἐρατοσθένης #footnote[Ἐρατοσθένης (Eratosthenes) 这个名字的词源是 _ἐρᾰτός_ (eratós, #text(lang: "en")[“lovely”]) + _σθένος_ (sthénos, #text(lang: "en")[“strong”])。] 质数筛，改写自Euler原文。
 
   对比
   $

--- a/fourier.typ
+++ b/fourier.typ
@@ -1,6 +1,4 @@
-#import "@preview/tablex:0.0.6": tablex, hlinex, vlinex, cellx
-
-#import "template.typ": project, example, remark
+#import "template.typ": project, example, remark, table-header
 
 // Workaround for footnote style
 #show link: set text(fill: blue)
@@ -31,13 +29,12 @@ $
   以 $k |-> gcd(k, 4)$ 为例。
   #align(
     center,
-    tablex(
+    table(
       columns: (auto, auto, auto, auto, auto, auto, auto, auto, auto, auto, auto, auto),
       align: center,
-      auto-hlines: false,
-      auto-vlines: false,
-      [*$k$*], vlinex(), $dots.c$, $[1$, $2$, $3$, $4]$, $[5$, $6$, $7$, $8]$, $9$, $dots.c$,
-      hlinex(),
+      stroke: none,
+      [*$k$*], table.vline(), $dots.c$, $[1$, $2$, $3$, $4]$, $[5$, $6$, $7$, $8]$, $9$, $dots.c$,
+      table.hline(),
       [*$gcd(k, 4)$*], $dots.c$, $[1$, $2$, $1$, $4]$, $[1$, $2$, $1$, $4]$, $1$, $dots.c$,
     )
   )
@@ -74,21 +71,17 @@ $
 @tab:units 介绍了最基础的三个数论函数 $1, id, delta$。
 
 #figure(
-  tablex(
-    columns: (auto, auto, auto),
-    align: center,
-    auto-vlines: false,
-    auto-hlines: false,
-    [*记号*], vlinex(), [*定义*], vlinex(), [*意义*],
-    hlinex(),
+  table(
+    columns: 3,
+    align: (x, y) => (if y == 0 or x < 2 { center } else { start }) + horizon,
+    table-header[记号][定义][意义],
     $1$, $1(n) equiv 1$,
-    cellx(align: start)[恒一，函数相乘的单位元：$f times 1 = 1 times f = f$],
+    [恒一，函数相乘的单位元：$f times 1 = 1 times f = f$],
     $id$, $id(n) equiv n$,
-    cellx(align: start)[恒等，函数复合的单位元：$f compose id = id compose f = f$],
+    [恒等，函数复合的单位元：$f compose id = id compose f = f$],
     $delta$, $delta(n) = cases(1 &space n = 1, 0 &space n != 1)$,
-    cellx(align: start)[Dirac $delta$#footnote[有些文献写作 $n |-> delta_(n 1)$，这次 $delta$ 是 Kronecker $delta$。]，Dirichlet卷积的单位元：$f * delta = delta * f = f$],
+    [Dirac $delta$#footnote[有些文献写作 $n |-> delta_(n 1)$，这次 $delta$ 是 Kronecker $delta$。]，Dirichlet卷积的单位元：$f * delta = delta * f = f$],
   ),
-  kind: table,
   caption: [三种“单位”数论函数]
 ) <tab:units>
 

--- a/herglotz.typ
+++ b/herglotz.typ
@@ -1,4 +1,4 @@
-#import "@preview/physica:0.8.0": dd, dv, Re, Im, Res as _Res, order, eval, difference
+#import "@preview/physica:0.9.3": dd, dv, Re, Im, Res as _Res, Order, eval, difference
 #import "@preview/xarrow:0.2.0": xarrow
 
 #import "template.typ": project, remark, example, small, pseudonyms
@@ -204,7 +204,7 @@ $f$ 大约的确是 $x |-> pi cot(pi x)$ 了。
   - 在 $ZZ$ 上，$f$ 和 $cot$ 的 $oo$ 相互抵消，奇点可去。
 
     具体来说，$x -> 0$ 时，
-    - 前面判断 $f$ 收敛时已得 $f - 1\/x = order(x)$；
+    - 前面判断 $f$ 收敛时已得 $f - 1\/x = Order(x)$；
     - 又知 $cot x - 1\/x = (x - tan x)/(x tan x) tilde o(x^2) \/ x^2 = o(1)$。
     故 $g -> 0$。若补充定义 $g(0)=0$，$g$ 即连续。
 
@@ -371,7 +371,7 @@ $
 abs(f'(z))
 <= sum_(n in ZZ) 1 / abs(z+n)^2
 = 1/y sum_(n in ZZ) 1 / (1 + (x+n)^2/y^2) 1/y
-= 1/y order(pi/2)
+= 1/y Order(pi/2)
 -> 0.
 $
 由导数有界，$f(0+i oo)$ 有界，可得 $f([0,1] + i oo)$ 有界。至此得证。
@@ -422,9 +422,9 @@ $
     $
     (1/(z+zeta) - 1/z) pi cot(pi z)
     = -zeta/(z(z+zeta)) pi cot(pi z)
-    = order(1/R^2),
+    = Order(1/R^2),
     $
-    而边界长 $order(R)$，误差最多 $order(1/R)$。
+    而边界长 $Order(R)$，误差最多 $Order(1/R)$。
 ]
 
 #example[Basel 问题][
@@ -455,7 +455,7 @@ $
   $
   (cot z - 1\/z - 0)/z
   = (z - tan z)/(z^2 tan z)
-  tilde (-1/3 z^3 + order(z^5))/z^3
+  tilde (-1/3 z^3 + Order(z^5))/z^3
   -> -1/3.
   $
   因此

--- a/herglotz.typ
+++ b/herglotz.typ
@@ -141,9 +141,9 @@ $
 1. 根据性状，$f$ 接近 $cot$。
 
   #remark[词源][
-    正切 $tan$ 的 tangent 来自拉丁语 _tangens_ (≈ 英语的“touching”)，因为它是切线段长，而切线 _touches_ 单位圆。
+    正切 $tan$ 的 tangent 来自拉丁语 _tangens_ (≈ 英语的#text(lang: "en")[“touching”])，因为它是切线段长，而切线 _touches_ 单位圆。
 
-    余切 $cot$ 等的前缀 co- 来自 _complementi_ (≈ “complementary”)，指余角（complementary angle）。
+    余切 $cot$ 等的前缀 co- 来自 _complementi_ (≈ #text(lang: "en")[“complementary”])，指余角（complementary angle）。
   ]
 
 2. 根据周期 $1$，$f$ 可能是 $cot(pi x)$ 的倍数。

--- a/template.typ
+++ b/template.typ
@@ -34,14 +34,6 @@
   table.header(..headers.pos().map(strong))
 }
 
-// 中西共用标点默认全宽，破折号应不离不弃
-// TODO: 这样无法区分正文和`figure.caption`，引号高度可能不匹配汉字。
-// https://github.com/typst/typst/issues/3331
-#let _fix-zh-punctuations(font: "Source Han Serif", body) = {
-  show regex("[“‘’”]|——|……"): set text(font: font)
-  body
-}
-
 #let project(title: "", authors: (), date: none, body) = {
   // Set the document's basic properties.
   set document(author: authors, title: title)
@@ -54,7 +46,13 @@
 
   // Set body font family.
   set text(font: body-fonts, lang: "zh", region: "CN")
-  show text.where(lang: "zh"): _fix-zh-punctuations.with(font: body-fonts.at(1))
+  // 中西共用标点默认全宽，破折号应不离不弃
+  // TODO: 这样无法区分正文和`figure.caption`，引号高度可能不匹配汉字。
+  // https://github.com/typst/typst/issues/3331
+  show regex("[“‘’”]|——|……"): it => {
+    set text(font: body-fonts.at(1)) if text.lang == "zh"
+    it
+  }
   show heading: set text(font: sans-fonts)
   show raw: set text(font: ("Fira Code", ..sans-fonts))
   show figure.caption: set text(font: script-fonts)

--- a/template.typ
+++ b/template.typ
@@ -1,5 +1,4 @@
 #import "@preview/ctheorems:1.0.0": thmrules, thmbox
-#import "@preview/tablex:0.0.6": tablex, hlinex, vlinex
 
 #let remark = thmbox(
   "remark",
@@ -24,6 +23,15 @@
 ).with(numbering: none)
 
 #let small = text.with(size: 0.8em, fill: gray.darken(70%))
+
+// A stylized table header
+// TODO: Use a show rule on `table.header`.
+// It is not possible at least in typst v0.11. “That will be fixed in a future release.”
+// https://typst.app/docs/guides/table-guide/#basic-tables
+// https://github.com/typst/typst/issues/3640
+#let table-header(..headers) = {
+  table.header(..headers.pos().map(strong))
+}
 
 #let project(title: "", authors: (), date: none, body) = {
   // Set the document's basic properties.
@@ -63,6 +71,14 @@
   // Main body.
   set par(justify: true)
 
+  set table(
+    align: (x, y) => (if y == 0 { center } else { start }) + horizon,
+    stroke: (x, y) => (
+      if y == 0 { (bottom: 1pt + black) },
+      if x > 0 { (left: 1pt + black) },
+    ).sum(),
+  )
+
   show: thmrules
 
   show strong: set text(fill: blue.darken(10%))
@@ -92,17 +108,11 @@
   [#hashes.slice(1).map(row => row.at(0)).join("、")当然是化名，他们的真名按 UTF-8 编码的 SHA256
     如下。]
 
-  figure(tablex(
-    columns: (auto, auto),
-    align: center + horizon,
-    auto-vlines: false,
-    auto-hlines: false,
-    [*#hashes.at(0).at(0)*],
-    vlinex(),
-    [*#hashes.at(0).at(1)*],
-    hlinex(),
+  figure(table(
+    columns: 2,
+    table-header(..hashes.at(0)),
     ..hashes.slice(1).map(row => (row.at(0), raw(row.at(1)))).flatten(),
-  ), caption: [化名与真名的 hash], kind: table)
+  ), caption: [化名与真名的 hash])
 
   figure(
     raw(read(path + "/hash.py"), lang: "python", block: true),

--- a/template.typ
+++ b/template.typ
@@ -34,6 +34,14 @@
   table.header(..headers.pos().map(strong))
 }
 
+// 中西共用标点默认全宽，破折号应不离不弃
+// TODO: 这样无法区分正文和`figure.caption`，引号高度可能不匹配汉字。
+// https://github.com/typst/typst/issues/3331
+#let _fix-zh-punctuations(font: "Source Han Serif", body) = {
+  show regex("[“‘’”]|——|……"): set text(font: font)
+  body
+}
+
 #let project(title: "", authors: (), date: none, body) = {
   // Set the document's basic properties.
   set document(author: authors, title: title)
@@ -45,7 +53,8 @@
   let script-fonts = ("Inria Sans", "STKai")
 
   // Set body font family.
-  set text(font: body-fonts, lang: "zh")
+  set text(font: body-fonts, lang: "zh", region: "CN")
+  show text.where(lang: "zh"): _fix-zh-punctuations.with(font: body-fonts.at(1))
   show heading: set text(font: sans-fonts)
   show raw: set text(font: ("Fira Code", ..sans-fonts))
   show figure.caption: set text(font: script-fonts)

--- a/template.typ
+++ b/template.typ
@@ -1,25 +1,26 @@
-#import "@preview/ctheorems:1.0.0": thmrules, thmbox
+#import "@preview/ctheorems:1.1.2": thmrules, thmbox
+
+#let _thmbox_fmt = (
+  // 开头的负空白用于抵消 head、name 之间的空格。
+  namefmt: (name) => text(weight: "bold", [#h(-1em/4)（#name] + box(width: 1em)[）#h(-1em/4).]),
+  separator: h(0.5em),
+  breakable: true,
+)
 
 #let remark = thmbox(
   "remark",
   "注",
   titlefmt: text.with(fill: purple.darken(10%), weight: "bold"),
-  // -0.5em 用于抵消 head、name 之间的空格。
-  namefmt: (name) => text(weight: "bold")[#h(-0.5em)（#name）],
-  separator: text(weight: "bold")[.#h(0.5em)],
-  breakable: true,
   stroke: (left: purple),
+  .._thmbox_fmt,
 ).with(numbering: none)
 
 #let example = thmbox(
   "example",
   "例",
   titlefmt: text.with(fill: green.darken(10%), weight: "bold"),
-  // -0.5em 用于抵消 head、name 之间的空格。
-  namefmt: (name) => text(weight: "bold")[#h(-0.5em)（#name）],
-  separator: text(weight: "bold")[.#h(0.5em)],
-  breakable: true,
   stroke: (left: green),
+  .._thmbox_fmt,
 ).with(numbering: none)
 
 #let small = text.with(size: 0.8em, fill: gray.darken(70%))


### PR DESCRIPTION
新版typst（最迟 v0.11.1）能在PDF中正确生成`/ToUnicode`，复制出来不乱码。

## 未来工作

- xarrow → https://staging.typst.app/docs/reference/math/stretch/ (https://github.com/typst/typst/issues/1304)
- https://github.com/sahasatvik/typst-theorems/issues/34

